### PR TITLE
Docs: mention JS Array::join default separator

### DIFF
--- a/docs/js/array/join.md
+++ b/docs/js/array/join.md
@@ -6,3 +6,5 @@ Adds all the elements of an array separated by the specified separator string.
 const a = [0, 1, 2, 3, 4];
 const b = a.join("-");      // "0-1-2-3-4"
 ```
+
+The default is a comma (",").


### PR DESCRIPTION
I always forget it's a comma, not a space.