### PR TITLE
Fixed wat tour

### DIFF
--- a/dist/clerk/clerk.js
+++ b/dist/clerk/clerk.js
@@ -365,7 +365,7 @@ var clerk = {
       mkdirp.sync(dir);
       fs.appendFileSync(file, data, { flag: 'w' });
     } catch (e) {
-      this.log('Error saving to the local filesystem: ', e);
+      console.log('Error saving to the local filesystem: ', e);
     }
   }
 };


### PR DESCRIPTION
I attempted to run 'wat tour' after installing it and was greeted by this error:
![wattour](https://cloud.githubusercontent.com/assets/3011854/11358815/20015882-9244-11e5-9636-ec168de36d60.PNG)
I changed one line which seemed to fix it for me, just this.log to console.log.

Also I reran `gulp index`, but am unsure about if I should've added the files in config and am unsure where this log would be defined.